### PR TITLE
Added the missing import to fix  ReferenceError.

### DIFF
--- a/web/audio-processor.js
+++ b/web/audio-processor.js
@@ -1,4 +1,5 @@
 import { settings } from './state.js';
+import { mapFrame } from './grid-dispatcher.js';
 import { playSineWave } from './synthesis-methods/engines/sine-wave.js';
 import { playFMSynthesis } from './synthesis-methods/engines/fm-synthesis.js';
 


### PR DESCRIPTION
Added import { mapFrame } from './grid-dispatcher.js'; at the top to provide mapFrame for playAudio.