### PR TITLE
Addressing the Error:

### DIFF
--- a/web/audio-processor.js
+++ b/web/audio-processor.js
@@ -8,7 +8,7 @@ export let isAudioInitialized = false;
 export let oscillators = [];
 
 export async function initializeAudio(context) {
-    if (isAudioInitialized) return;
+    if (isAudioInitialized || !context) return;
     try {
         audioContext = context;
         if (audioContext.state === 'suspended') {

--- a/web/main.js
+++ b/web/main.js
@@ -1,6 +1,3 @@
-import { initializeAudio } from './audio-processor.js';
 import { setupUI } from './ui-handlers.js';
-
 // Initialize the application
-initializeAudio();
 setupUI();


### PR DESCRIPTION
TypeError (audioContext undefined): Removing the initializeAudio call from main.js ensures audioContext is only created in ui-handlers.js on user gesture, preventing undefined errors.